### PR TITLE
set kobuki branch to melodic

### DIFF
--- a/install_all.sh
+++ b/install_all.sh
@@ -26,7 +26,7 @@ git clone https://github.com/yujinrobot/kobuki_desktop.git
 cd kobuki_desktop/
 rm -r kobuki_qtestsuite
 cd -
-git clone https://github.com/yujinrobot/kobuki.git
+git clone --single-branch --branch melodic https://github.com/yujinrobot/kobuki.git
 mv kobuki/kobuki_description kobuki/kobuki_bumper2pc \
   kobuki/kobuki_node kobuki/kobuki_keyop \
   kobuki/kobuki_safety_controller ./

--- a/install_basic.sh
+++ b/install_basic.sh
@@ -9,7 +9,7 @@ git clone https://github.com/turtlebot/turtlebot_apps.git
 git clone https://github.com/turtlebot/turtlebot_simulator
 
 git clone https://github.com/yujinrobot/kobuki_msgs.git
-git clone https://github.com/yujinrobot/kobuki.git
+git clone --single-branch --branch melodic https://github.com/yujinrobot/kobuki.git
 mv kobuki/kobuki_description kobuki/kobuki_node \
   kobuki/kobuki_keyop kobuki/kobuki_safety_controller \
   kobuki/kobuki_bumper2pc ./


### PR DESCRIPTION
The default devel branch had some breaking changes related to variable renaming.
https://github.com/yujinrobot/kobuki_msgs/pull/11

I explicitly set the branch to melodic when cloning kobuki.

Thanks.
