### PR TITLE
add missing dependencies

### DIFF
--- a/install_all.sh
+++ b/install_all.sh
@@ -3,7 +3,7 @@
 mkdir -p src
 cd src
 
-git clone https://github.com/turtlebot/turtlebot_simulator
+git clone https://github.com/turtlebot/turtlebot_simulator.git
 git clone https://github.com/turtlebot/turtlebot.git
 git clone https://github.com/turtlebot/turtlebot_apps.git
 git clone https://github.com/turtlebot/turtlebot_msgs.git
@@ -37,3 +37,4 @@ rm -rf yujin_ocs
 
 sudo apt-get install ros-melodic-kobuki-* -y
 sudo apt-get install ros-melodic-ecl-streams -y
+sudo apt-get install ros-melodic-yocs-velocity-smoother -y

--- a/install_basic.sh
+++ b/install_basic.sh
@@ -9,7 +9,7 @@ cd src
 git clone https://github.com/turtlebot/turtlebot.git
 git clone https://github.com/turtlebot/turtlebot_msgs.git
 git clone https://github.com/turtlebot/turtlebot_apps.git
-git clone https://github.com/turtlebot/turtlebot_simulator
+git clone https://github.com/turtlebot/turtlebot_simulator.git
 
 git clone https://github.com/yujinrobot/kobuki_msgs.git
 git clone --single-branch --branch melodic https://github.com/yujinrobot/kobuki.git
@@ -17,6 +17,10 @@ mv kobuki/kobuki_description kobuki/kobuki_node \
   kobuki/kobuki_keyop kobuki/kobuki_safety_controller \
   kobuki/kobuki_bumper2pc ./
 rm -rf kobuki
+
+git clone --single-branch --branch melodic https://github.com/yujinrobot/kobuki_desktop.git
+mv kobuki_desktop/kobuki_gazebo_plugins ./
+rm -rf kobuki_desktop
 
 git clone https://github.com/yujinrobot/yujin_ocs.git
 mv yujin_ocs/yocs_cmd_vel_mux yujin_ocs/yocs_controllers .
@@ -28,3 +32,4 @@ sudo apt-get install ros-melodic-ecl-streams -y
 # necessary for build and gazebo
 sudo apt-get install ros-melodic-depthimage-to-laserscan -y
 sudo apt-get install ros-melodic-joy -y
+sudo apt-get install ros-melodic-yocs-velocity-smoother -y


### PR DESCRIPTION
I tested on a fresh new Ubuntu 18 OS. The current `install_basic.sh` doesn't work in the sense that no `/odom` topic is publishing in Gazebo and also no topics under `mobile_base` namespace are handling the velocity commands. According to solutions in previous issues https://github.com/gaunthan/Turtlebot2-On-Melodic/issues/5#issuecomment-613639459, https://github.com/gaunthan/Turtlebot2-On-Melodic/issues/2#issuecomment-562667082, and https://github.com/gaunthan/Turtlebot2-On-Melodic/issues/2#issuecomment-563581360, I made this patch. Now it works fine. 